### PR TITLE
Fix Rhel font issue on SSH connection.

### DIFF
--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -171,5 +171,6 @@
       - pango-devel
       - pulseaudio-libs-devel
       - uuid-devel
+      - google-droid-sans-mono-fonts
   when:
     - ansible_os_family == "RedHat"


### PR DESCRIPTION
This PR is related to #14, it will deploy a new font named `google-droid-sans-mono-fonts` to avoid text issue on SSH connection. This issue has been found on a Centos 7 stock.
