### PR TITLE
make postgres optionnal

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -207,6 +207,7 @@
     privs: SELECT,INSERT,UPDATE,DELETE
   become: true
   become_user: postgres
+  when: guacamole_postgresql_auth
 
 - name: config | Setting DB permissions
   postgresql_privs:
@@ -218,6 +219,7 @@
     privs: all
   become: true
   become_user: postgres
+  when: guacamole_postgresql_auth
 
 - name: config | Marking DB As Populated # noqa 503
   file:


### PR DESCRIPTION
Otherwise, the role is failing (with the default & empty custom config)

<!--- Provide a short summary of your changes in the Title above -->

## Description
Add a when condition on progres module to make postgres optional

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
