### PR TITLE
Fix Guacamole DL URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,11 +22,11 @@ guacamole_auth_openid_priority: ""
 # Defines if MySQL DB should be used for authentication
 guacamole_mysql_auth: false
 
-guacamole_mysql_connector_package: "{{ guacamole_mysql_connector_dl_url + 'mysql-connector-java-' + guacamole_mysql_connector_version + '.tar.gz' }}"
+guacamole_mysql_connector_package: "{{ guacamole_mysql_connector_dl_url + 'mysql-connector-j-' + guacamole_mysql_connector_version + '.tar.gz' }}"
 
-guacamole_mysql_connector_dl_url: https://dev.mysql.com/get/Downloads/Connector-J/
+guacamole_mysql_connector_dl_url: https://cdn.mysql.com//Downloads/Connector-J/
 
-guacamole_mysql_connector_version: 8.0.13
+guacamole_mysql_connector_version: 8.0.33
 
 # Defines if PostgreSQL DB should be used for authentication
 guacamole_postgresql_auth: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -77,7 +77,7 @@
 
 - name: config | Copying MySQL Connector # noqa risky-file-permissions
   ansible.builtin.copy:
-    src: "{{ guacamole_src_dir + '/' + 'mysql-connector-java-' + guacamole_mysql_connector_version + '/' + 'mysql-connector-java-' + guacamole_mysql_connector_version + '.jar' }}"
+    src: "{{ guacamole_src_dir + '/' + 'mysql-connector-j-' + guacamole_mysql_connector_version + '/' + 'mysql-connector-j-' + guacamole_mysql_connector_version + '.jar' }}"
     dest: /etc/guacamole/lib/
     owner: "{{ guacamole_tomcat_user }}"
     group: "{{ guacamole_tomcat_user }}"


### PR DESCRIPTION
Fix error 404 : Page Not Found
- update url link
- Use a more recent version ( from 8.0.13 to 8.0.33) for guacamole_mysql_connector
- File have been renamed from `mysql-connector-java-` to `mysql-connector-j-`

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Fix error 404 : Page Not Found on https://dev.mysql.com/get/Downloads/Connector-J/
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
