### PR TITLE
Support multiple guacamole backend at the same time

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,7 +81,7 @@ guacamole_server_package: "{{ 'guacamole-server-' + guacamole_version + '.tar.gz
 
 guacamole_server_port: 4822
 
-#guacamole_basic_user_mapping: /etc/guacamole/user-mapping.xml
+guacamole_basic_user_mapping: /etc/guacamole/user-mapping.xml
 
 guacamole_src_dir: /usr/local/src
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -37,7 +37,7 @@
     - "restart {{ guacamole_tomcat_service }}"
     - kill guacd
     - restart guacd
-  when: guacamole_users is defined
+  when: guacamole_users is defined and guacamole_users | list | length >= 1
 
 - name: config | Downloading Auth JDBC Library
   ansible.builtin.unarchive:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -37,7 +37,7 @@
     - "restart {{ guacamole_tomcat_service }}"
     - kill guacd
     - restart guacd
-  when: not guacamole_mysql_auth and not guacamole_postgresql_auth
+  when: guacamole_users is defined
 
 - name: config | Downloading Auth JDBC Library
   ansible.builtin.unarchive:


### PR DESCRIPTION
- mysql (or postgres) database is not replacing the user-mapping
- both (or even all backend) can be used at the same time (for testing i was able to use ldap, mysql and user-mapping backend with the same account in guacamole

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
