### PR TITLE
Enable optional attribut for user-mapping

### DIFF
--- a/templates/etc/guacamole/user-mapping.xml.j2
+++ b/templates/etc/guacamole/user-mapping.xml.j2
@@ -8,7 +8,9 @@
         <connection name="{{ connection['name'] }}">
             <protocol>{{ connection['protocol'] }}</protocol>
             <param name="hostname">{{ connection['host'] }}</param>
+{%           if connection['port'] is defined %}
             <param name="port">{{ connection['port'] }}</param>
+{%           endif %}
 {%         if connection['protocol'] == "rdp" %}
             <param name="color-depth">{{ guacamole_rdp_color_depth }}</param>
             <param name="security">{{ guacamole_rdp_security }}</param>
@@ -24,6 +26,9 @@
 {%         if connection['protocol'] == "ssh" %}
 {%           if connection['private_key'] is defined %}
             <param name="private-key">{{ connection['private_key'] }}</param>
+{%           endif %}
+{%           if connection['enable_sftp'] is defined %}
+            <param name="enable-sftp">{{ connection['enable_sftp'] }}</param>
 {%           endif %}
 {%         endif %}
         </connection>


### PR DESCRIPTION
Adding 2 optional attribut on user-mapping.xml
* port of the destination server
* enable_sftp for ssh connexion

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
