### PR TITLE
add TOTP guacamole backend

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ guacamole_dl_url: "{{ 'http://apache.org/dyn/closer.cgi?action=download&filename
 
 guacamole_server_hostname: localhost
 
+# Authentication TOPT
+guacamole_auth_totp_package: "{{ 'guacamole-auth-totp-' + guacamole_version + '.tar.gz' }}"
+
 # Authentication OpenID
 guacamole_auth_openid_package: "{{ 'guacamole-auth-openid-' + guacamole_version + '.tar.gz' }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,3 +22,7 @@
 
 - name: Manage Guacamole client configurations
   ansible.builtin.include_tasks: client.yml
+
+- name: Manage Guacamole TOTP configurations
+  ansible.builtin.include_tasks: totp.yml
+  when: guacamole_totp | default(false) | bool

--- a/tasks/totp.yml
+++ b/tasks/totp.yml
@@ -1,0 +1,20 @@
+---
+# Documentation : https://guacamole.apache.org/doc/gug/totp-auth.html
+
+- name: config | Downloading Auth TOTP Library
+  ansible.builtin.unarchive:
+    src: "{{ guacamole_dl_url + '/binary/' + guacamole_auth_totp_package }}"
+    dest: "{{ guacamole_src_dir }}"
+    remote_src: true
+  become: true
+
+- name: config | Copying Auth TOTP Connector  # noqa risky-file-permissions
+  ansible.builtin.copy:
+    src: "{{ guacamole_src_dir + '/' + 'guacamole-auth-totp-' + guacamole_version + '/' + 'guacamole-auth-totp-' + guacamole_version + '.jar' }}"
+    dest: /etc/guacamole/extensions/
+    owner: "{{ guacamole_tomcat_user }}"
+    group: "{{ guacamole_tomcat_user }}"
+    remote_src: true
+  become: true
+  notify:
+    - "restart {{ guacamole_tomcat_service }}"


### PR DESCRIPTION
* disabled by default

<!--- Provide a short summary of your changes in the Title above -->

## Description
add TOTP authentification (mfa) backend in guacamole

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [c] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
