### PR TITLE
add 2 optional mysql configuration :

### DIFF
--- a/templates/etc/guacamole/guacamole.properties.j2
+++ b/templates/etc/guacamole/guacamole.properties.j2
@@ -14,6 +14,12 @@ mysql-port: {{ guacamole_mysql_db['port'] }}
 mysql-database: {{ guacamole_mysql_db['name'] }}
 mysql-username: {{ guacamole_mysql_db['username'] }}
 mysql-password: {{ guacamole_mysql_db['password'] }}
+{% if guacamole_mysql_db['sslmode'] is defined %}
+mysql-ssl-mode: {{ guacamole_mysql_db['sslmode'] }}
+{% endif %}
+{% if guacamole_mysql_db['timezone'] is defined %}
+mysql-server-timezone: {{ guacamole_mysql_db['timezone'] }}
+{% endif %}
 {% endif %}
 {% if guacamole_postgresql_auth %}
 postgresql-hostname: {{ guacamole_postgresql_db['host'] }}


### PR DESCRIPTION
add 2 optional mysql configuration :
- guacamole_mysql_db['sslmode']
- guacamole_mysql_db['timezone']

<!--- Provide a short summary of your changes in the Title above -->

## Description
Minor change, it's permitting to specify the sslmode & timezone in mysql backend

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
