### PR TITLE
Permit redirect tomcat ROOT to guacamole.war

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -247,10 +247,9 @@
     - kill guacd
     - restart guacd
 
-- name: Update index.hmtl of ROOT in tomcat to redirect to guacamole webapps
+- name: Update index.hmtl of ROOT in tomcat to redirect to guacamole webapps # noqa no-handler risky-file-permissions
   ansible.builtin.copy:
     content: "<meta http-equiv='Refresh' content=\"0; url='{{ guacamole_redirect }}'\"/>"
     dest: "{{ '/var/lib/' + guacamole_tomcat + '/webapps/ROOT/index.html' }}"
   when: guacamole_redirect is defined
   become: true
-

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -246,3 +246,11 @@
     - "restart {{ guacamole_tomcat_service }}"
     - kill guacd
     - restart guacd
+
+- name: Update index.hmtl of ROOT in tomcat to redirect to guacamole webapps
+  ansible.builtin.copy:
+    content: "<meta http-equiv='Refresh' content=\"0; url='{{ guacamole_redirect }}'\"/>"
+    dest: "{{ '/var/lib/' + guacamole_tomcat + '/webapps/ROOT/index.html' }}"
+  when: guacamole_redirect is defined
+  become: true
+


### PR DESCRIPTION
Optional task to permit a simplest URL for user
We used as this (behind a HAProxy) :
```
guacamole_redirect: https://guacamole.exemple.com/guacamole/#/
```

It's permit to use `https://guacamole.exemple.com` URL instead of `https://guacamole.exemple.com/guacamole`

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
