### PR TITLE
Add a new tasks to (optional) configure guacd daemon

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -12,6 +12,19 @@
     - /etc/guacamole/lib
     - /etc/guacamole/extensions
 
+- name: config | Configuring guacd
+  ansible.builtin.template:
+    src: etc/guacamole/guacd.conf.j2
+    dest: /etc/guacamole/guacd.conf
+    owner: "{{ guacamole_tomcat_user }}"
+    group: "{{ guacamole_tomcat_user }}"
+    mode: u=rw,g=r,o=r
+  become: true
+  notify:
+    - kill guacd
+    - restart guacd
+  when: guacd_config is defined
+
 - name: config | Configuring guacamole.properties
   ansible.builtin.template:
     src: etc/guacamole/guacamole.properties.j2

--- a/templates/etc/guacamole/guacd.conf.j2
+++ b/templates/etc/guacamole/guacd.conf.j2
@@ -1,0 +1,29 @@
+{% if guacd_config.daemon is defined %}
+[daemon]
+{% if guacd_config.daemon.pid_file is defined %}
+pid_file = {{ guacd_config.daemon.pid_file }}
+{% endif %}
+{% if guacd_config.daemon.log_level is defined %}
+log_level = {{ guacd_config.daemon.log_level }}
+{% endif %}
+{% endif %}
+
+{% if guacd_config.server is defined %}
+[server]
+{% if guacd_config.server.bind_host is defined %}
+bind_host = {{ guacd_config.server.bind_host }}
+{% endif %}
+{% if guacd_config.server.bind_port is defined %}
+bind_port = {{ guacd_config.server.bind_port }}
+{% endif %}
+{% endif %}
+
+{% if guacd_config.ssl is defined %}
+[ssl]
+{% if guacd_config.ssl.server_certificate is defined %}
+server_certificate = {{ guacd_config.ssl.server_certificate }}
+{% endif %}
+{% if guacd_config.ssl.server_key is defined %}
+server_key = {{ guacd_config.ssl.server_key }}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
* If guacd_config variable is not set, nothing is added
* Example how to set specific configuration to guacd :
```
guacd_config:
  daemon:
    pid_file: /var/run/guacd.pid
    log_level: debug
  server:
    bind_host: 127.0.0.1
    bind_port: 4822
```
* or with ssl
```
guacd_config:
  daemon:
    pid_file: /var/run/guacd.pid
    log_level: debug
  server:
    bind_host: 127.0.0.1
    bind_port: 4822
  ssl:
    server_certificate: /etc/ssl/certs/guacd.crt
    server_key: /etc/ssl/private/guacd.key
```

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
