### PR TITLE
Permit upgrade guacamole version

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,7 @@
     src: "{{ guacamole_src_dir + '/' + guacamole_server_package }}"
     dest: "{{ guacamole_src_dir }}"
     remote_src: true
+  register: extract
   become: true
 
 - name: install | Checking If Guacamole Server Is Installed
@@ -23,7 +24,7 @@
     chdir: "{{ guacamole_src_dir + '/guacamole-server-' + guacamole_version }}"
   become: true
   register: _guacamole_config_server_build
-  when: not _guacamole_server_installed['stat']['exists']
+  when: not _guacamole_server_installed['stat']['exists'] or extract.changed
 
 - name: install | Compiling Guacamole Server # noqa no-handler
   community.general.make:


### PR DESCRIPTION
Hi @mrlesmithjr ,

actually as the binary compiled is already existing, this ansible role never updating the guacamole version

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
