### PR TITLE
Permit guacamole install without guacd

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,12 +3,14 @@
 - name: kill guacd # noqa no-changed-when
   ansible.builtin.command: pkill guacd
   become: true
+  when: guacd_config is defined
 
 - name: restart guacd
   ansible.builtin.service:
     name: guacd
     state: restarted
   become: true
+  when: guacd_config is defined
 
 - name: restart tomcat
   ansible.builtin.service:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,11 +14,11 @@
 
 - name: install | Checking If Guacamole Server Is Installed
   ansible.builtin.stat:
-    path: /usr/local/sbin/guacd
+    path: /usr/local/bin/guaclog
   register: _guacamole_server_installed
 
 - name: install | Configuring Guacamole Server Build # noqa no-changed-when
-  ansible.builtin.command: ./configure --with-init-dir=/etc/init.d
+  ansible.builtin.command: "./configure --with-init-dir=/etc/init.d{% if guacd_config is not defined %} --disable-guacd{% endif %}"
   args:
     chdir: "{{ guacamole_src_dir + '/guacamole-server-' + guacamole_version }}"
   become: true

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -5,3 +5,4 @@
     enabled: true
     state: started
   become: true
+  when: guacd_config is defined


### PR DESCRIPTION
guacd can be install on another machine as exemple

@mrlesmithjr , it's not the same subject but it's a bug on the guacamole 1.5.4 and it's failing the compile

Workarround for this bug in 1.5.4 : https://lists.apache.org/thread/h5zql3zdov0ngh8kp9r3yppcprq5z1jf is to add on the `install | Configuring Guacamole Server Build` playbook tasks this :
```
  environment:
    LDFLAGS: '-lrt'
```
But i'm not sure if it's a good idea to add it for all version, ...

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
