### PR TITLE
war file with version

### DIFF
--- a/tasks/client.yml
+++ b/tasks/client.yml
@@ -2,26 +2,40 @@
 - name: client | Downloading Guacamole Client Package # noqa risky-file-permissions
   ansible.builtin.get_url:
     url: "{{ guacamole_dl_url + '/binary/' + guacamole_client_package }}"
-    dest: /etc/guacamole/guacamole.war
+    dest: "{{ '/etc/guacamole/guacamole-' + guacamole_version + '.war' }}"
   become: true
   register: dl
   until: dl is success
 
 - name: client | Creating Tomcat Symlink For {{ 'guacamole-' + guacamole_version + '.war' }}
   ansible.builtin.file:
-    src: /etc/guacamole/guacamole.war
-    dest: "{{ '/var/lib/' + guacamole_tomcat + '/webapps/guacamole.war' }}"
+    src: "{{ '/etc/guacamole/guacamole-' + guacamole_version + '.war' }}"
+    dest: "{{ '/var/lib/' + guacamole_tomcat + '/webapps/guacamole##' + guacamole_version + '.war' }}"
     state: link
   become: true
   notify:
     - "restart {{ guacamole_tomcat_service }}"
     - kill guacd
     - restart guacd
+- name: client | list if any Previous guacamole deployed war
+  ansible.builtin.find:
+    paths: "{{ '/var/lib/' + guacamole_tomcat + '/webapps/' }}"
+    excludes: "{{ 'guacamole##' + guacamole_version + '.war' }}"
+    file_type: link
+  register: guacamole_previous_wars
+
+- name: client | Delete previous guacamole deployed war
+  ansible.builtin.file:
+    path: "{{ guacamole_previous_war.path }}"
+    state: absent
+  loop: "{{ guacamole_previous_wars.files }}"
+  loop_control:
+    loop_var: guacamole_previous_war
 
 # Moving here to ensure idempotency as it was failing when included above
 - name: client | Setting Permissions On Tomcat Symlink For {{ 'guacamole-' + guacamole_version + '.war' }}
   ansible.builtin.file:
-    path: /etc/guacamole/guacamole.war
+    path: "{{ '/etc/guacamole/guacamole-' + guacamole_version + '.war' }}"
     owner: "{{ guacamole_tomcat_user }}"
     group: "{{ guacamole_tomcat_user }}"
   become: true


### PR DESCRIPTION
In term of functionally, it's permit :
- permit to restore previous guacamole version
- easily change version of guacamole
- the guacamole war version used is visible on the tomcat management webpage

Technically this change is done in 3 parts:
- replace /etc/guacamole/guacamole.war with the version like /etc/guacamole/guacamole-1.5.4.war
- replace link destination /var/lib/tomcat9/webapps/guacamole.war to /var/lib/tomcat9/webapps/guacamole##1.5.4.war
- New tasks : `client | Delete previous guacamole deployed war`

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
