### PR TITLE
add a set_fact when guacamole version is 1.5.4 and debian OS

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,6 +25,8 @@
   become: true
   register: _guacamole_config_server_build
   when: not _guacamole_server_installed['stat']['exists'] or extract.changed
+  # Workarround for this bug in 1.5.4 : https://lists.apache.org/thread/h5zql3zdov0ngh8kp9r3yppcprq5z1jf
+  environment: "{{ guacamole_compile_environment | default(omit) }}"
 
 - name: install | Compiling Guacamole Server # noqa no-handler
   community.general.make:
@@ -32,6 +34,8 @@
   become: true
   register: _guacamole_server_compiled
   when: _guacamole_config_server_build['changed']
+  # Workarround for this bug in 1.5.4 : https://lists.apache.org/thread/h5zql3zdov0ngh8kp9r3yppcprq5z1jf
+  environment: "{{ guacamole_compile_environment | default(omit) }}"
 
 - name: install | Installing Guacamole Server # noqa no-handler
   community.general.make:

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -178,3 +178,12 @@
       - uuid-devel
   when:
     - ansible_os_family == "RedHat"
+
+- name: set_facts | Fix guacamole 1.5.4 compile issue
+  ansible.builtin.set_fact:
+    guacamole_compile_environment:
+      LDFLAGS: '-lrt'
+  when:
+    - ansible_distribution == "Debian"
+    - ansible_distribution_version is version('9', '>=')
+    - guacamole_version == "1.5.4"


### PR DESCRIPTION
Fixing issue #46 

it's will set a environment to permit compile guacamole
if the env is enable on old version (like 1.5.3), it's failed to compile sadly it's produce a warning on ansible-playbook :
```
[WARNING]: could not parse environment value, skipping: ['{{ guacamole_compile_environment | default(omit) }}']
```
The when condition can easily add other OS version as they also impacted about this compile issue

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
