### PR TITLE
Make installation of guacd a config option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ guacamole_openid:
   redirect-uri: https://remote.xxx.xx/guacamole
 ```
 
+### guacd Configuration
+
+guacd is the native server-side proxy used by the Apache Guacamole web application. If you wish to deploy Guacamole, or an application using the Guacamole core APIs, you will need a copy of guacd running.
+
+guacd is installed by default. To disable it, set `guacd_config.install` to `false`:
+
+```
+guacd_config:
+  install: false
+```
+
 ## Dependencies
 
 ## Example Playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -111,3 +111,6 @@ guacamole_users: []
 # Define version to install
 # 0.9.13-incubating | 0.9.14 | 1.0.0 | 1.1.0
 guacamole_version: 1.1.0
+
+guacd_config:
+  install: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,14 +3,14 @@
 - name: kill guacd # noqa no-changed-when
   ansible.builtin.command: pkill guacd
   become: true
-  when: guacd_config is defined
+  when: guacd_config.install
 
 - name: restart guacd
   ansible.builtin.service:
     name: guacd
     state: restarted
   become: true
-  when: guacd_config is defined
+  when: guacd_config.install
 
 - name: restart tomcat
   ansible.builtin.service:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -23,7 +23,7 @@
   notify:
     - kill guacd
     - restart guacd
-  when: guacd_config is defined
+  when: guacd_config.install
 
 - name: config | Configuring guacamole.properties
   ansible.builtin.template:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,7 +19,7 @@
   register: _guacamole_server_installed
 
 - name: install | Configuring Guacamole Server Build # noqa no-changed-when
-  ansible.builtin.command: "./configure --with-init-dir=/etc/init.d{% if guacd_config is not defined %} --disable-guacd{% endif %}"
+  ansible.builtin.command: "./configure --with-init-dir=/etc/init.d{% if not guacd_config.install %} --disable-guacd{% endif %}"
   args:
     chdir: "{{ guacamole_src_dir + '/guacamole-server-' + guacamole_version }}"
   become: true

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -5,4 +5,4 @@
     enabled: true
     state: started
   become: true
-  when: guacd_config is defined
+  when: guacd_config.install


### PR DESCRIPTION
Pull request to solve issue of guacd not installing by default. See https://github.com/mrlesmithjr/ansible-guacamole/issues/58 for details.

As we cannot unset variables in ansible I have chosen to use a new "guacd_config.install" variable that defaults to true, and have updated the relevant checks to use this. 

Tested on fresh Ubuntu 22.04 install.
